### PR TITLE
Fix linter warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,15 +127,6 @@ Edge: Not sure on this one. It'll take some debugging. I tried text-overflow, ov
 </details>
 
 <details>
-<summary>Fix minor console errors</summary>
-<h4>Problem:</h4> 
-There are a few minor (yellow) errors I didn't look into fixing since they were from my initial assessment not performance impairing in any way, and more for convention. In the case of the re-declares I found it better to break that rule in some cases. 
-
-<h4>Solution/steps:</h4> 
-If you believe these are worth fixing and I'm wrong in some way send a pull request with the fix and a small explanation of why it's a good idea to fix them. It shouldn't be too hard to do, and maybe I'll learn something :) 
-</details>
-
-<details>
 <summary>Implement jump to the top button</summary>
 <h4>Problem:</h4> People with a lot of saves will have to scroll pretty far up to the top. This can be an inconvenience for mobile users.  
 

--- a/src/components/FilterSaves.js
+++ b/src/components/FilterSaves.js
@@ -71,15 +71,13 @@ class FilterSaves extends React.Component {
           </div>
         )
       }
-      if (save.type === comment) {
-        return (
-          <div className="save-wrapper" key={save.key}>
-            <div className="index"> {i+1}. </div>
-            {save.displaySubreddit_c}
-            {save.displayComment}
-          </div>
-        )
-      }
+      return (
+        <div className="save-wrapper" key={save.key}>
+          <div className="index"> {i+1}. </div>
+          {save.displaySubreddit_c}
+          {save.displayComment}
+        </div>
+      )
     })
   }
 

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -13,29 +13,29 @@ class Header extends React.Component {
   handleButtons = event => {
 
     var { savesGridContainer } = this.props
-    var savesGridContainer = savesGridContainer.current.classList
+    var savesGridContainerClasses = savesGridContainer.current.classList
     var { savesGrid } = this.props
-    var savesGrid = savesGrid.current.classList
+    var savesGridClasses = savesGrid.current.classList
 
       const buttonID = event.target.id;
       switch (buttonID) {
 
           case 'btn-all-saves':
               this.props.displayThreadsAndComments(true);
-              savesGridContainer.remove('growSavesGridContainer');
-              savesGrid.remove('saves-grid-padding-threads')
+              savesGridContainerClasses.remove('growSavesGridContainer');
+              savesGridClasses.remove('saves-grid-padding-threads')
               break;
 
           case 'btn-only-threads':
               this.props.displayOnlyThreads(true);
-              savesGridContainer.add('growSavesGridContainer');
-              savesGrid.add('saves-grid-padding-threads')
+              savesGridContainerClasses.add('growSavesGridContainer');
+              savesGridClasses.add('saves-grid-padding-threads')
               break;
 
           case 'btn-only-comments':
               this.props.displayOnlyComments(true);
-              savesGridContainer.remove('growSavesGridContainer');
-              savesGrid.remove('saves-grid-padding-threads')
+              savesGridContainerClasses.remove('growSavesGridContainer');
+              savesGridClasses.remove('saves-grid-padding-threads')
               break;
 
           default:

--- a/src/containers/Pagination.js
+++ b/src/containers/Pagination.js
@@ -24,8 +24,7 @@ class Pagination extends React.Component {
       var nextPage = await axios.get (`https://oauth.reddit.com/user/${this.props.username}/saved/.json?limit=100&after=${currentPage}`, {
       headers: { 'Authorization': `bearer ${this.props.token}` }
     })
-      var nextPage = nextPage.data.data.children
-      const withNextPage = nextPage
+      const withNextPage = nextPage.data.data.children
       this.props.updateCurrentPageSaves(withNextPage)
       this.props.storeUserSaves(withNextPage)
     }


### PR DESCRIPTION
Hey, I fixed the linter warnings that were present in your app.  
The fixes are easy and it's good practice to keep warnings to a minimum wherever possible.

> If you believe these are worth fixing and I'm wrong in some way send a pull request with the fix and a small explanation of why it's a good idea to fix them.

**Regarding the [no-redeclare](https://eslint.org/docs/rules/no-redeclare) rule**

Redeclaring the same variable multiple times is usually discouraged and it's very easy to fix.  
Moreover if you start using `const` and `let` exclusively (which you should) you wouldn't even be able to redeclare the same variable since it will throw an error.

**Regarding the [array-callback-return](https://eslint.org/docs/rules/array-callback-return) rule**

I fixed it by removing the last `if` so the code always returns something.  
This assumes that if `save.type` is not `'t3'` then it must be `'t1'`.  
If that's not the case you may want to handle that third case in another way.