### PR TITLE
Fix overriding Safari default input styling

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -74,6 +74,7 @@ form {
   font-size: 16px;
   padding-right: 30px;
   -webkit-animation: image_blur_searchbar 2s; 
+  -webkit-appearance: none;
 }
 
 .searchBox::-webkit-search-cancel-button {


### PR DESCRIPTION
Fixed overriding Safari default input styling from this
![Before](https://i.imgur.com/6o8mcBK.png)
to this
![After](https://i.imgur.com/gqReM46.png)
